### PR TITLE
Empty group blowout fix.

### DIFF
--- a/Security/User/adUserProvider.php
+++ b/Security/User/adUserProvider.php
@@ -107,7 +107,7 @@ class adUserProvider implements UserProviderInterface
             $groups = array();
             //$allGroups = $adLdap->search_groups(ADLDAP_SECURITY_GLOBAL_GROUP,true);
             foreach($user->memberOf as $k=>$group){
-                if($k !== 'count'){
+                if($k !== 'count' && $group){
                     $reg = '#CN=([^,]*)#' ;
                     preg_match_all($reg,$group,$out);
                     $groups[] = $out[1][0] ;


### PR DESCRIPTION
The last element of $group was returning a bool(false) element and throwing an exception:

`Notice: Undefined offset: 0 in vendor/ztec/security-active_directory/Ztec/Security/ActiveDirectoryBundle/Security/User/adUserProvider.php line 113
500 Internal Server Error - ErrorException`

This occurred on on all 2008R2 machines I had access to test on and across several different domains.  Added a quick check to see if the Boolean is false.
