### PR TITLE
recursive group roles, PSR2 code styling

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -8,7 +8,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 /**
  * This is the class that validates and merges configuration from your app/config files
  *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * To learn more see
+ * {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  */
 class Configuration implements ConfigurationInterface
 {

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You need to configure your domain specific information
             use_ssl : false #Set it true need configuration of the server to be usefull
             use_tls : false #Set it true need configuration of the server to be usefull
             recursive_groups : false #Used Only for group test (not userInfo)
+			recursive_grouproles: false #recursive group roles
             sso : false #Use NTML. Not yet compatible with Symfony !!!
             username_patterns: #username is extracted from the string the user put into the login form
               - /([^@]*)@riper.fr/i  # like toto@riper.fr

--- a/Security/Authentication/AdAuthProvider.php
+++ b/Security/Authentication/AdAuthProvider.php
@@ -1,26 +1,29 @@
 <?php
-namespace Ztec\Security\ActiveDirectoryBundle\Security\Authentication ;
 
-use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface ;
-use Ztec\Security\ActiveDirectoryBundle\Security\User\adUserProvider ;
-use Ztec\Security\ActiveDirectoryBundle\Security\User\adUser ;
+namespace Ztec\Security\ActiveDirectoryBundle\Security\Authentication;
+
+use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
+use Ztec\Security\ActiveDirectoryBundle\Security\User\adUserProvider;
+use Ztec\Security\ActiveDirectoryBundle\Security\User\adUser;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException ;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Ztec\Security\ActiveDirectoryBundle\Service\AdldapService ;
+use Ztec\Security\ActiveDirectoryBundle\Service\AdldapService;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
-class AdAuthProvider implements AuthenticationProviderInterface{
+class AdAuthProvider implements AuthenticationProviderInterface
+{
 
     /**
      * @var \Ztec\Security\ActiveDirectoryBundle\Security\User\adUserProvider
      */
-    private $userProvider ;
+    private $userProvider;
 
-    public function __construct(adUserProvider $userProvider,$config, AdldapService $AdldapService){
-        $this->userProvider = $userProvider ;
-        $this->config = $config ;
-        $this->AdldapService = $AdldapService ;
+    public function __construct(adUserProvider $userProvider, $config, AdldapService $AdldapService)
+    {
+        $this->userProvider = $userProvider;
+        $this->config = $config;
+        $this->AdldapService = $AdldapService;
     }
 
     /**
@@ -36,17 +39,22 @@ class AdAuthProvider implements AuthenticationProviderInterface{
     {
         $Adldap = $this->AdldapService->getInstance();
         $User = $this->userProvider->loadUserByUsername($token->getUsername());
-        if($User instanceof adUser){
-            if(!$Adldap->authenticate($User->getUsername(),$token->getCredentials())){
+        if ($User instanceof adUser) {
+            if (!$Adldap->authenticate($User->getUsername(), $token->getCredentials())) {
                 throw new BadCredentialsException('The credentials are wrong');
             }
             $User->setPassword($token->getCredentials());
-            $this->userProvider->fetchData($User,$Adldap);
+            $this->userProvider->fetchData($User, $Adldap);
         }
 
-        $newToken = new UsernamePasswordToken($User, $token->getCredentials(), "ztec.security.active.directory.user.provider", $User->getRoles()) ;
+        $newToken = new UsernamePasswordToken(
+            $User,
+            $token->getCredentials(),
+            "ztec.security.active.directory.user.provider",
+            $User->getRoles()
+        );
 
-        return $newToken ;
+        return $newToken;
     }
 
     /**
@@ -56,8 +64,8 @@ class AdAuthProvider implements AuthenticationProviderInterface{
      *
      * @return Boolean true if the implementation supports the Token, false otherwise
      */
-    function supports(TokenInterface $token)
+    public function supports(TokenInterface $token)
     {
-        return $token instanceof UsernamePasswordToken ;
+        return $token instanceof UsernamePasswordToken;
     }
 }

--- a/Security/Factory/AdAuthFactory.php
+++ b/Security/Factory/AdAuthFactory.php
@@ -1,18 +1,20 @@
 <?php
-namespace Ztec\Security\ActiveDirectoryBundle\Security\Factory ;
+
+namespace Ztec\Security\ActiveDirectoryBundle\Security\Factory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
-use  Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory ;
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginFactory ;
+use  Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginFactory;
 
-class AdAuthFactory extends  FormLoginFactory {
+class AdAuthFactory extends FormLoginFactory
+{
 
-
-    public function __construct(){
+    public function __construct()
+    {
         parent::__construct();
         $this->addOption('account_suffix', 'domain.local');
     }
@@ -33,21 +35,22 @@ class AdAuthFactory extends  FormLoginFactory {
 
         $providerId = 'security.authentication.provider.ztec.active_directory.'.$id;
         $container
-            ->setDefinition($providerId, new DefinitionDecorator('ztec.security.active.directory.authentication.provider'))
+            ->setDefinition(
+                $providerId,
+                new DefinitionDecorator('ztec.security.active.directory.authentication.provider')
+            )
             ->replaceArgument(0, new Reference("ztec.security.active.directory.user.provider"))
-            ->replaceArgument(1, $config)
-        ;
+            ->replaceArgument(1, $config);
         //exit();
-        return $providerId ;
+        return $providerId;
     }
 
     /*public function getListenerId(){
         return
     }*/
 
-
     public function getKey()
     {
-        return 'active_directory' ;
+        return 'active_directory';
     }
 }

--- a/Security/User/adUser.php
+++ b/Security/User/adUser.php
@@ -1,5 +1,6 @@
 <?php
-namespace Ztec\Security\ActiveDirectoryBundle\Security\User ;
+
+namespace Ztec\Security\ActiveDirectoryBundle\Security\User;
 
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -12,12 +13,12 @@ class adUser implements UserInterface
     private $roles;
 
 
-    public function __construct($username,$password,array $roles)
+    public function __construct($username, $password, array $roles)
     {
         $this->username = $username;
-        $this->password = $password ;
+        $this->password = $password;
         $this->salt = '';
-        $this->roles = $roles ;
+        $this->roles = $roles;
     }
 
     /**
@@ -33,8 +34,9 @@ class adUser implements UserInterface
         return $this->password;
     }
 
-    public function setPassword($password){
-        $this->password = $password ;
+    public function setPassword($password)
+    {
+        $this->password = $password;
     }
 
     /**
@@ -46,7 +48,7 @@ class adUser implements UserInterface
      */
     public function getSalt()
     {
-        return null ;
+        return null;
     }
 
     /**
@@ -69,7 +71,7 @@ class adUser implements UserInterface
      */
     public function eraseCredentials()
     {
-        //return void ;
+        //return void;
     }
 
     /**
@@ -90,14 +92,11 @@ class adUser implements UserInterface
      */
     public function getRoles()
     {
-        return  $this->roles ;
+        return  $this->roles;
     }
 
-    public function setRoles(array $roles){
-        $this->roles = $roles ;
+    public function setRoles(array $roles)
+    {
+        $this->roles = $roles;
     }
-
-
-
-
 }

--- a/Security/User/adUserProvider.php
+++ b/Security/User/adUserProvider.php
@@ -1,20 +1,22 @@
 <?php
+
 namespace Ztec\Security\ActiveDirectoryBundle\Security\User;
+
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Ztec\Security\ActiveDirectoryBundle\Service\AdldapService;
-use adLDAP\adLDAP ;
+use adLDAP\adLDAP;
 
 class adUserProvider implements UserProviderInterface
 {
-    private $usernamePatterns = array() ;
+    private $usernamePatterns = array();
     public function __construct(ContainerInterface $Container, AdldapService $AdldapService)
     {
         $this->container = $Container;
-        $this->AdldapService = $AdldapService ;
+        $this->AdldapService = $AdldapService;
         $config = $Container->getParameter('ztec.security.active_directory.settings');
         if (isset($config['username_patterns']) && is_array($config['username_patterns'])) {
             foreach ($config['username_patterns'] as $pat) {
@@ -44,7 +46,7 @@ class adUserProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
 
-        $user = new adUser($this->getUsernameFromString($username),'42',array());
+        $user = new adUser($this->getUsernameFromString($username), '42', array());
         return $user;
         //throw new UsernameNotFoundException(sprintf('Username "%s" does not exist.', $username));
     }
@@ -59,7 +61,7 @@ class adUserProvider implements UserProviderInterface
             }
         }
         $username = strtolower($username);
-        /*echo $username ;*/
+        /*echo $username;*/
         if (preg_match('/^[a-z0-9-.]+$/i', $username) == true) {
             /* echo 'ok';
              exit();*/
@@ -96,11 +98,16 @@ class adUserProvider implements UserProviderInterface
     }
 
 
-    public function fetchData(adUser $adUser, adLDAP $adLdap){
+    public function fetchData(adUser $adUser, adLDAP $adLdap)
+    {
         $connected = $adLdap->connect();
-        $isAD = $adLdap->authenticate($adUser->getUsername(),$adUser->getPassword());
-        if(!$isAD || !$connected){
-            throw new \Exception('Active directory dit not respond well '.var_export($isAD,1). ' - '.var_export($connected,1));
+        $isAD = $adLdap->authenticate($adUser->getUsername(), $adUser->getPassword());
+        if (!$isAD || !$connected) {
+            throw new \Exception(
+                'Active directory dit not respond well ' .
+                var_export($isAD, 1) . ' - ' .
+                var_export($connected, 1)
+            );
         }
         $user = $adLdap->user()->infoCollection($adUser->getUsername());
         //$userInfo = $adLdap->user_info($this->username);
@@ -111,13 +118,13 @@ class adUserProvider implements UserProviderInterface
 
             if ($this->recursiveGrouproles == true) {
                 // get recursive groups via adLdap
-                $groups = $adLdap->user()->groups($adUser->getUsername(),true);
+                $groups = $adLdap->user()->groups($adUser->getUsername(), true);
             } else {
-                foreach($user->memberOf as $k=>$group){
-                    if($k !== 'count' && $group){
-                        $reg = '#CN=([^,]*)#' ;
-                        preg_match_all($reg,$group,$out);
-                        $groups[] = $out[1][0] ;
+                foreach ($user->memberOf as $k => $group) {
+                    if ($k !== 'count' && $group) {
+                        $reg = '#CN=([^,]*)#';
+                        preg_match_all($reg, $group, $out);
+                        $groups[] = $out[1][0];
                         /* if(array_key_exists($out[1][0],$allGroups)){
                              $groups[$out[1][0]] = $allGroups[$out[1][0]];
                          }*/
@@ -128,11 +135,11 @@ class adUserProvider implements UserProviderInterface
 
             $roles = array('USER','Domain_users');
             $sfRoles = array();
-            foreach($groups as $r){
-                $sfRoles[] = 'ROLE_'.strtoupper(str_replace(' ','_',$r));
+            foreach ($groups as $r) {
+                $sfRoles[] = 'ROLE_' . strtoupper(str_replace(' ', '_', $r));
             }
             $adUser->setRoles($sfRoles);
-            return TRUE ;
+            return true;
         }
     }
 

--- a/Service/AdldapService.php
+++ b/Service/AdldapService.php
@@ -1,30 +1,34 @@
 <?php
-namespace Ztec\Security\ActiveDirectoryBundle\Service ;
+
+namespace Ztec\Security\ActiveDirectoryBundle\Service;
+
 use adLDAP\adLDAP;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class AdldapService {
+class AdldapService
+{
     /**
      * @var adLDAP The instance of adLdap used for each call of the service
      */
-    private $adLdap ;
+    private $adLdap;
 
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerInterface $container  Dependency injection
      */
-    function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container)
     {
-        $this->container = $container ;
+        $this->container = $container;
         $parameters = $container->getParameter('ztec.security.active_directory.settings');
-        $parameters['account_suffix'] = '@'.$parameters['account_suffix'];
-        $this->paramerters = $parameters ;
+        $parameters['account_suffix'] = '@' . $parameters['account_suffix'];
+        $this->paramerters = $parameters;
     }
 
     /**
      * @return adLDAP The instance of the adLdap (lib)
      */
-    public function getInstance(){
+    public function getInstance()
+    {
         $this->adLdap = new adLDAP($this->paramerters);
-        return $this->adLdap ;
+        return $this->adLdap;
     }
 }

--- a/ZtecSecurityActiveDirectoryBundle.php
+++ b/ZtecSecurityActiveDirectoryBundle.php
@@ -3,8 +3,8 @@
 namespace Ztec\Security\ActiveDirectoryBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder ;
-use Ztec\Security\ActiveDirectoryBundle\Security\Factory\AdAuthFactory ;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Ztec\Security\ActiveDirectoryBundle\Security\Factory\AdAuthFactory;
 
 class ZtecSecurityActiveDirectoryBundle extends Bundle
 {


### PR DESCRIPTION
1.) Recursive group roles with use of the recursive groups function from adLDAP ($adLdap->user()->groups); new configuration parameter: recursive_grouproles

2.) refactored code to comply with PSR code styling guidelines (tested with php codesniffer psr2 rules); two exceptions: class names violating camel caps format have not been edited to not break existing code (adUser, adUserProvider)
