### PR TITLE
custom user name validation pattern, customizable messages on login failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ You need to configure your domain specific information
               - /RIPER\\(.*)/i #like RIPER\toto
               - /RIPER.FR\\(.*)/i #like RIEPER.FR\toto
               - /(.*)/i #like toto
+            username_validation_pattern: /^[a-z0-9-.]+$/i #optional: regex to check the form of the user name before auth
+            message_invalid_user: Invalid user name
+            message_bad_credentials: The credentials are wrong
 
 You need to add security parameters
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -10,7 +10,7 @@ services:
 
     ztec.security.active.directory.authentication.provider:
         class: "%ztec_security_active_directory_authentication_provider.class%"
-        arguments: [ "@ztec.security.active.directory.user.provider", "", "@ztec.security.active.directory.service.adldap"]
+        arguments: [ "@ztec.security.active.directory.user.provider", "", "@ztec.security.active.directory.service.adldap", "@service_container"]
 
     ztec.security.active.directory.service.adldap:
         class: "%ztec_security_active_directory_service_adldap.class%"

--- a/Security/Factory/AdAuthFactory.php
+++ b/Security/Factory/AdAuthFactory.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
-use  Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FormLoginFactory;
 
 class AdAuthFactory extends FormLoginFactory


### PR DESCRIPTION
- customized messages for invalid username and bad credentials (new parameters: message_invalid_user, message_bad_credentials)
- custom username validation pattern (regex) via config paramter (username_validation_pattern)
- function loadUserByUsername() now throws UsernameNotFoundException() on invalid username
- function getUsernameFromString() returns null value instead of throwing InvalidArgument exception
