### PR TITLE
Fix package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Installation
 You need to add a package to your dependency list :
 
     // composer.json
-    "riper/active_directory": "1.*"
+    "riper/security-active_directory": "1.*"
 
 You need to enable the bundle into your kernel
 


### PR DESCRIPTION
The package name in composer.json is riper/security-active_directory, however the manual refers to riper/active_directory.
