### PR TITLE
Replacing security.context to security.token_storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ php_ldap
 
 ssl configuration for LDAP. see http://adldap.sourceforge.net/wiki/doku.php?id=ldap_over_ssl
 
-Compatible with Symfony 2 starting from 2.1
+Compatible with Symfony 2 starting from 2.6
 
 
 Installation

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,4 +22,4 @@ services:
 
     riper.security.active.directory.factory.adldap:
         class: "Riper\Security\ActiveDirectoryBundle\Security\Factory\AdldapFactory"
-        arguments: [ @security.context, @riper.security.active.directory.service.adldap ]
+        arguments: [ @security.token_storage, @riper.security.active.directory.service.adldap ]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
 
     riper.security.active.directory.authentication.provider:
         class: Riper\Security\ActiveDirectoryBundle\Security\Authentication\AdAuthProvider
-        arguments: ["@riper.security.active.directory.user.provider", "", "@riper.security.active.directory.service.adldap", "@translator", "%riper_security_tokens_classes%", %riper.security.active_directory.settings% ]
+        arguments: ["@riper.security.active.directory.user.provider", "", "@riper.security.active.directory.service.adldap", "@translator", "%riper_security_tokens_classes%", "%riper.security.active_directory.settings%" ]
 
     riper.security.active.directory.service.adldap:
         class: Riper\Security\ActiveDirectoryBundle\Service\AdldapService

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,5 +21,5 @@ services:
         arguments: [ "%riper.security.active_directory.settings%"]
 
     riper.security.active.directory.factory.adldap:
-        class: Riper\Security\ActiveDirectoryBundle\Security\Factory\AdldapFactory
-        arguments: [ "@security.context", "@riper.security.active.directory.service.adldap" ]
+        class: "Riper\Security\ActiveDirectoryBundle\Security\Factory\AdldapFactory"
+        arguments: [ "@security.token_storage", "@riper.security.active.directory.service.adldap" ]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,22 +4,22 @@ parameters:
     riper_security_active_directory_token_faulty : Riper\Security\ActiveDirectoryBundle\Security\Token\FaultyToken
 
     riper_security_tokens_classes :
-        standard : %riper_security_active_directory_token%
-        faulty : %riper_security_active_directory_token_faulty%
+        standard : "%riper_security_active_directory_token%"
+        faulty : "%riper_security_active_directory_token_faulty%"
 
 services:
     riper.security.active.directory.user.provider:
-        class: "Riper\Security\ActiveDirectoryBundle\Security\User\AdUserProvider"
+        class: Riper\Security\ActiveDirectoryBundle\Security\User\AdUserProvider
         arguments: ["%riper.security.active_directory.settings%", "@riper.security.active.directory.service.adldap", "@translator"]
 
     riper.security.active.directory.authentication.provider:
-        class: "Riper\Security\ActiveDirectoryBundle\Security\Authentication\AdAuthProvider"
+        class: Riper\Security\ActiveDirectoryBundle\Security\Authentication\AdAuthProvider
         arguments: ["@riper.security.active.directory.user.provider", "", "@riper.security.active.directory.service.adldap", "@translator", "%riper_security_tokens_classes%", %riper.security.active_directory.settings% ]
 
     riper.security.active.directory.service.adldap:
-        class: "Riper\Security\ActiveDirectoryBundle\Service\AdldapService"
+        class: Riper\Security\ActiveDirectoryBundle\Service\AdldapService
         arguments: [ "%riper.security.active_directory.settings%"]
 
     riper.security.active.directory.factory.adldap:
-        class: "Riper\Security\ActiveDirectoryBundle\Security\Factory\AdldapFactory"
-        arguments: [ @security.context, @riper.security.active.directory.service.adldap ]
+        class: Riper\Security\ActiveDirectoryBundle\Security\Factory\AdldapFactory
+        arguments: [ "@security.context", "@riper.security.active.directory.service.adldap" ]

--- a/Security/Factory/AdldapFactory.php
+++ b/Security/Factory/AdldapFactory.php
@@ -5,7 +5,7 @@ namespace Riper\Security\ActiveDirectoryBundle\Security\Factory;
 
 use Riper\Security\ActiveDirectoryBundle\Exception\WrongTokenException;
 use Riper\Security\ActiveDirectoryBundle\Service\AdldapService;
-use Riper\Security\ActiveDirectoryBundle\Token\FaultyToken;
+use Riper\Security\ActiveDirectoryBundle\Security\Token\FaultyToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\SecurityContext;
 

--- a/Security/Factory/AdldapFactory.php
+++ b/Security/Factory/AdldapFactory.php
@@ -3,10 +3,10 @@
 
 namespace Riper\Security\ActiveDirectoryBundle\Security\Factory;
 
-
 use Riper\Security\ActiveDirectoryBundle\Exception\WrongTokenException;
 use Riper\Security\ActiveDirectoryBundle\Service\AdldapService;
 use Riper\Security\ActiveDirectoryBundle\Token\FaultyToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\SecurityContext;
 
 class AdldapFactory
@@ -15,23 +15,23 @@ class AdldapFactory
     /**
      * @var SecurityContext
      */
-    private $securityContext;
+    private $tokenStorage;
 
     /**
      * @var AdldapService
      */
     private $adldapService;
 
-    public function __construct(SecurityContext $securityContext, AdldapService $adldapService)
+    public function __construct(TokenStorage $tokenStorage, AdldapService $adldapService)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->adldapService = $adldapService;
     }
 
 
     public function getAuthenticatedAdLdap()
     {
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
         if ($token instanceof FaultyToken) {
             throw new WrongTokenException(
                 'The token is not the right one. Did you forget to set "keep_password_in_token" to "true" in bundle configuration ?'


### PR DESCRIPTION
to stop throwing deprecation log in 2.8 an higher, we should change the service `security.context` to `security.token_storage`.

But this change will make a bc break to all version <= 2.6 (refs [this article in sf blog](http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements))

Of course,  this PR should be accepted only after the PR #20 and some change might be needed after the merge.
