### PR TITLE
Replacing security.context to security.token_storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ php_ldap
 
 ssl configuration for LDAP. see http://adldap.sourceforge.net/wiki/doku.php?id=ldap_over_ssl
 
-Compatible with Symfony 2 starting from 2.1
+Compatible with Symfony 2 starting from 2.6
 
 
 Installation

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,4 +22,4 @@ services:
 
     riper.security.active.directory.factory.adldap:
         class: Riper\Security\ActiveDirectoryBundle\Security\Factory\AdldapFactory
-        arguments: [ "@security.context", "@riper.security.active.directory.service.adldap" ]
+        arguments: [ "@security.token_storage", "@riper.security.active.directory.service.adldap" ]

--- a/Security/Factory/AdldapFactory.php
+++ b/Security/Factory/AdldapFactory.php
@@ -3,35 +3,34 @@
 
 namespace Riper\Security\ActiveDirectoryBundle\Security\Factory;
 
-
 use Riper\Security\ActiveDirectoryBundle\Exception\WrongTokenException;
 use Riper\Security\ActiveDirectoryBundle\Service\AdldapService;
-use Riper\Security\ActiveDirectoryBundle\Token\FaultyToken;
-use Symfony\Component\Security\Core\SecurityContext;
+use Riper\Security\ActiveDirectoryBundle\Security\Token\FaultyToken;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
 class AdldapFactory
 {
 
     /**
-     * @var SecurityContext
+     * @var TokenStorage
      */
-    private $securityContext;
+    private $tokenStorage;
 
     /**
      * @var AdldapService
      */
     private $adldapService;
 
-    public function __construct(SecurityContext $securityContext, AdldapService $adldapService)
+    public function __construct(TokenStorage $tokenStorage, AdldapService $adldapService)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->adldapService = $adldapService;
     }
 
 
     public function getAuthenticatedAdLdap()
     {
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
         if ($token instanceof FaultyToken) {
             throw new WrongTokenException(
                 'The token is not the right one. Did you forget to set "keep_password_in_token" to "true" in bundle configuration ?'


### PR DESCRIPTION
Same PR as #21 but to v2.x branch instead of v1.x
