### PR TITLE
Pass firewall ID to created tokens

### DIFF
--- a/Security/Authentication/AdAuthProvider.php
+++ b/Security/Authentication/AdAuthProvider.php
@@ -67,14 +67,14 @@ class AdAuthProvider implements AuthenticationProviderInterface
             $newToken = new $this->tokenClasses['faulty'](
                 $User,
                 $token->getCredentials(),
-                'riper.security.active.directory.user.provider',
+                $this->config['firewall_id'],
                 $User->getRoles()
             );
         } else {
             $newToken = new $this->tokenClasses['standard'](
                 $User,
                 $token->getCredentials(),
-                'riper.security.active.directory.user.provider',
+                $this->config['firewall_id'],
                 $User->getRoles()
             );
         }

--- a/Security/Factory/AdAuthFactory.php
+++ b/Security/Factory/AdAuthFactory.php
@@ -22,13 +22,15 @@ class AdAuthFactory extends FormLoginFactory
      *
      * @param ContainerBuilder $container
      * @param string $id             The unique id of the firewall
-     * @param array $config         The options array for this listener
+     * @param array  $config         The options array for this listener
      * @param string $userProviderId The id of the user provider
      *
      * @return string never null, the id of the authentication provider
      */
     protected function createAuthProvider(ContainerBuilder $container, $id, $config, $userProviderId)
     {
+        $config['firewall_id'] = $id;
+
         $providerId = 'security.authentication.provider.riper.active_directory.' . $id;
         $container
             ->setDefinition(


### PR DESCRIPTION
The firewall ID must be passed to the UsernamePasswordToken to ensure that authentication is done correctly if there are multiple firewalls.
Having a hard-coded value prevents the AuthProvider to be used for more than one firewall.

In addition, a provider key which does not match the actual firewall ID prevents the Twig functions logout_path() and logout_url() to work correctly ("No LogoutListener found for firewall key").

Adding the firewall ID to the auth provider configuration, as it is not there by default, seemed the easiest option for now. Another way would be to pass the providerKey as an additional constructor argument of the AuthenticationProvider. However, this would change the method signature and require adaptations of the service definitions.

See [`Symfony\Component\Security\Core\Authentication\Provider\UserAuthenticationProvider`](https://github.com/symfony/symfony/blob/v4.0.2/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php#L38) for the implementation in the Symfony default authentication provider base class. The actual creation of the provider happens [here](https://github.com/symfony/symfony/blob/v4.0.2/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php#L62)  (in the case of the DAO authentication provider).